### PR TITLE
Direct access to model's UPDATED_AT

### DIFF
--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -131,7 +131,7 @@ class Searcher
         $modelToSearchThrough = new ModelToSearchThrough(
             is_string($query) ? $query::query() : $query,
             Collection::wrap($columns),
-            $orderByColumn ?? $query::UPDATED_AT,
+            $orderByColumn ?? get_class(new $query)::UPDATED_AT,
             $this->modelsToSearchThrough->count()
         );
 

--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -131,7 +131,7 @@ class Searcher
         $modelToSearchThrough = new ModelToSearchThrough(
             is_string($query) ? $query::query() : $query,
             Collection::wrap($columns),
-            $orderByColumn ?? constant("{$query}::UPDATED_AT"),
+            $orderByColumn ?? (String) constant("{$query}::UPDATED_AT"),
             $this->modelsToSearchThrough->count()
         );
 

--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -126,12 +126,12 @@ class Searcher
      * @param string $orderByColumn
      * @return self
      */
-    public function add($query, $columns = null, string $orderByColumn = 'updated_at'): self
+    public function add($query, $columns = null, string $orderByColumn = null): self
     {
         $modelToSearchThrough = new ModelToSearchThrough(
             is_string($query) ? $query::query() : $query,
             Collection::wrap($columns),
-            $orderByColumn,
+            $orderByColumn ?? $query::UPDATED_AT,
             $this->modelsToSearchThrough->count()
         );
 
@@ -149,7 +149,7 @@ class Searcher
      * @param string $orderByColumn
      * @return self
      */
-    public function addWhen($value, $query, $columns = null, string $orderByColumn = 'updated_at'): self
+    public function addWhen($value, $query, $columns = null, string $orderByColumn = null): self
     {
         if (!$value) {
             return $this;

--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -128,10 +128,12 @@ class Searcher
      */
     public function add($query, $columns = null, string $orderByColumn = null): self
     {
+        $queryBuilder = is_string($query) ? $query::query() : $query;
+
         $modelToSearchThrough = new ModelToSearchThrough(
-            is_string($query) ? $query::query() : $query,
+            $queryBuilder,
             Collection::wrap($columns),
-            $orderByColumn ?? (String) constant("{$query}::UPDATED_AT"),
+            $orderByColumn ?: $queryBuilder->getUpdatedAtColumn(),
             $this->modelsToSearchThrough->count()
         );
 

--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -131,7 +131,7 @@ class Searcher
         $modelToSearchThrough = new ModelToSearchThrough(
             is_string($query) ? $query::query() : $query,
             Collection::wrap($columns),
-            $orderByColumn ?? get_class(new $query)::UPDATED_AT,
+            $orderByColumn ?? constant("{$query}::UPDATED_AT"),
             $this->modelsToSearchThrough->count()
         );
 


### PR DESCRIPTION
This PR is to direct access to Model::UPDATED_AT 

Some project may not use Laravel's default column name as "updated_at" and it is troublesome for the user to replace custom "updated_at" on each search created.

**From**
```php
$results = Search::add(Product::class, 'CHEMICAL', 'UPDATEDDATE')->get('resist');
```

**To**
```php
$results = Search::add(Product::class, 'CHEMICAL')->get('resist');
```

**Model**
```php
class Product extends Model
{
    const UPDATED_AT = 'UPDATEDDATE';
}
```

Cheers.