### PR TITLE
Add Conditionable trait to Searcher

### DIFF
--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -13,9 +13,12 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 
 class Searcher
 {
+    use Conditionable;
+
     /**
      * Collection of models to search through.
      */

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use ProtoneMedia\LaravelCrossEloquentSearch\OrderByRelevanceException;
 use ProtoneMedia\LaravelCrossEloquentSearch\Search;
+use ProtoneMedia\LaravelCrossEloquentSearch\Searcher;
 
 class SearchTest extends TestCase
 {
@@ -653,5 +654,25 @@ class SearchTest extends TestCase
 
         $this->assertTrue($resultA->first()->is($postA));
         $this->assertTrue($resultB->first()->is($postA));
+    }
+
+    /** @test */
+    public function it_can_conditionally_apply_ordering()
+    {
+        Carbon::setTestNow(now());
+        $postA = Post::create(['title' => 'foo']);
+
+        Carbon::setTestNow(now()->subDay());
+        $postB = Post::create(['title' => 'foo2']);
+
+        $results = Search::add(Post::class, 'title')
+            ->when(true, fn (Searcher $searcher) => $searcher->orderByDesc())
+            ->get('foo');
+
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertCount(2, $results);
+
+        $this->assertTrue($results->first()->is($postA));
+        $this->assertTrue($results->last()->is($postB));
     }
 }


### PR DESCRIPTION
This pull request adds the 'Conditionable' trait to the Searcher class which allows one to easily apply certain queries based on some conditions. This is quite useful if you want to determine the sorting order based on the incoming request or if you want to add certain models for specific user roles. For example:

```php
Search::add(Post::class, 'title')
    ->when(
        request()->user()->isAn('admin'),
        fn (Searcher $searcher) => $searcher->add(Video::class, 'title'),
    )
    ->when(
        request()->get('sortDesc') === 'true',
        fn (Searcher $searcher) => $searcher->orderByDesc(),
        fn (Searcher $searcher) => $searcher->orderByAsc(),
    )
    ->get('foo');
```