### PR TITLE
add prefix to table name

### DIFF
--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -509,10 +509,9 @@ class Searcher
             throw OrderByRelevanceException::new();
         }
 
-        $expressionsAndBindings = $modelToSearchThrough->getQualifiedColumns()->flatMap(function ($field) use($modelToSearchThrough) {
+        $expressionsAndBindings = $modelToSearchThrough->getQualifiedColumns()->flatMap(function ($field) use ($modelToSearchThrough) {
             $prefix = $modelToSearchThrough->getModel()->getConnection()->getTablePrefix();
-            $field = $prefix . $field;
-            $field = (new MySqlGrammar)->wrap($field);
+            $field = (new MySqlGrammar)->wrap($prefix . $field);
 
             return $this->termsWithoutWildcards->map(function ($term) use ($field) {
                 return [

--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -509,7 +509,9 @@ class Searcher
             throw OrderByRelevanceException::new();
         }
 
-        $expressionsAndBindings = $modelToSearchThrough->getQualifiedColumns()->flatMap(function ($field) {
+        $expressionsAndBindings = $modelToSearchThrough->getQualifiedColumns()->flatMap(function ($field) use($modelToSearchThrough) {
+            $prefix = $modelToSearchThrough->getModel()->getConnection()->getTablePrefix();
+            $field = $prefix . $field;
             $field = (new MySqlGrammar)->wrap($field);
 
             return $this->termsWithoutWildcards->map(function ($term) use ($field) {


### PR DESCRIPTION
Fixes #66. This add prefix to the table name when running the query for order by relevance