### PR TITLE
Load models only by id in getModelsPerType()

### DIFF
--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -703,7 +703,7 @@ class Searcher
                 $ids = $results->pluck($key)->filter();
 
                 return $ids->isNotEmpty()
-                    ? $modelToSearchThrough->getFreshBuilder()->whereKey($ids)->get()->keyBy->getKey()
+                    ? $modelToSearchThrough->getModel()->newQueryWithoutScopes()->whereKey($ids)->get()->keyBy->getKey()
                     : null;
             });
 


### PR DESCRIPTION
There is no need to use other query conditions (e.g. local and global scopes) here again, it's sufficient enough to load the models by id.